### PR TITLE
add identifier in `quiet` mode

### DIFF
--- a/src/prodigy_prot/cli.py
+++ b/src/prodigy_prot/cli.py
@@ -112,10 +112,10 @@ def main():
     tasks = []
     for input_f in input_list:
         models, _, _ = parse_structure(str(input_f))
-        identifier = Path(input_f).stem
         struct_path = Path(input_f)
 
         for model in models:
+            identifier = f"{struct_path.stem}_model{model.id}"
             tasks.append((model, identifier, args, struct_path))
 
     # Execute in parallel
@@ -159,8 +159,13 @@ def process_model(model: Model, identifier: str, args: argparse.Namespace, struc
     try:
         if not args.quiet:
             print("#" * 42)
-            print(f"[+] Processing structure {identifier}_model{model.id}")
-        prodigy = Prodigy(model, args.selection, args.temperature)
+            print(f"[+] Processing structure {identifier}")
+        prodigy = Prodigy(
+            model=model,
+            name=identifier,
+            selection=args.selection,
+            temp=args.temperature,
+        )
         prodigy.predict(
             distance_cutoff=args.distance_cutoff, acc_threshold=args.acc_threshold
         )

--- a/src/prodigy_prot/modules/prodigy.py
+++ b/src/prodigy_prot/modules/prodigy.py
@@ -104,6 +104,7 @@ class Prodigy:
     def __init__(
         self,
         model: Model,
+        name: str = "",
         selection: Optional[list[str]] = None,
         temp: float = 25.0,
     ):
@@ -113,6 +114,7 @@ class Prodigy:
         else:
             self.selection = selection
         self.model = model
+        self.name = name
         self.ic_network: list = []
         self.bins: dict[str, float] = {
             "CC": 0.0,
@@ -190,7 +192,7 @@ class Prodigy:
             handle = sys.stdout
 
         if quiet:
-            handle.write("{0}\t{1:8.3f}\n".format(self.model.id, self.ba_val))
+            handle.write("{0}\t{1:8.3f}\n".format(self.name, self.ba_val))
         else:
             handle.write(
                 "[+] No. of intermolecular contacts: {0}\n".format(len(self.ic_network))


### PR DESCRIPTION
# ===autogenerated===
This pull request updates how model identifiers are handled and displayed throughout the CLI and core module logic, making the naming of models more consistent and informative. The changes ensure that each `Prodigy` instance and its outputs use a composite identifier that includes both the structure stem and the model ID, improving clarity when processing multiple models.

### Identifier handling improvements

* In `src/prodigy_prot/cli.py`, the identifier for each model is now constructed as `"{struct_path.stem}_model{model.id}"` before being passed to tasks, ensuring consistent and informative naming.
* In `process_model`, the identifier is used directly in output messages, and the `Prodigy` object is initialized with the new `name` argument for clarity.

### `Prodigy` class enhancements

* The `Prodigy` class in `src/prodigy_prot/modules/prodigy.py` now accepts a `name` argument in its constructor, storing it as an instance variable for later use. [[1]](diffhunk://#diff-4364c56171c3f28e3a08a3c2f617941467b1c7eff3e5993908e0f14ae3bc8f18R107) [[2]](diffhunk://#diff-4364c56171c3f28e3a08a3c2f617941467b1c7eff3e5993908e0f14ae3bc8f18R117)
* The `print_prediction` method now outputs the composite `name` instead of just the model ID, ensuring that predictions are clearly associated with their source structure and model.